### PR TITLE
Only show public domain artworks

### DIFF
--- a/api/artic.js
+++ b/api/artic.js
@@ -3,7 +3,7 @@
 // ARTIC API
 //const noCors = 'https://cors-anywhere.herokuapp.com/';
 const noCors = 'https://api.allorigins.win/raw?url=';
-const searchURL = 'https://aggregator-data.artic.edu/api/v1/artworks/search';
+const searchURL = 'https://api.artic.edu/api/v1/artworks/search';
 const imageURL = ({image_id}, res) => `https://www.artic.edu/iiif/2/${image_id}/full/,${res}/0/default.jpg`;
 const query = '?query[bool][must][][term][classification_titles.keyword]=painting';
 const fields = '&fields=image_id,title,artist_title';

--- a/api/artic.js
+++ b/api/artic.js
@@ -1,8 +1,6 @@
 'strict mode';
 
 // ARTIC API
-//const noCors = 'https://cors-anywhere.herokuapp.com/';
-const noCors = 'https://api.allorigins.win/raw?url=';
 const searchURL = 'https://api.artic.edu/api/v1/artworks/search';
 const imageURL = ({image_id}, res) => `https://www.artic.edu/iiif/2/${image_id}/full/,${res}/0/default.jpg`;
 const query = '?query[bool][must][][term][classification_titles.keyword]=painting';
@@ -14,7 +12,7 @@ module.exports = {
         return json.data.filter((d) => d.image_id);
     },
     fetchImage: async function (obj, advicedResolution) {
-        const url = noCors + imageURL(obj, advicedResolution);
+        const url = imageURL(obj, advicedResolution);
         const blob = await fetch(url).then(res => res.blob());
         return {
             title: obj.title + " - " + obj.artist_title,

--- a/api/artic.js
+++ b/api/artic.js
@@ -3,7 +3,7 @@
 // ARTIC API
 const searchURL = 'https://api.artic.edu/api/v1/artworks/search';
 const imageURL = ({image_id}, res) => `https://www.artic.edu/iiif/2/${image_id}/full/,${res}/0/default.jpg`;
-const query = '?query[bool][must][][term][classification_titles.keyword]=painting';
+const query = '?query[bool][must][][term][classification_titles.keyword]=painting&query[bool][must][][term][is_public_domain]=true';
 const fields = '&fields=image_id,title,artist_title';
 module.exports = {
     fetchList: async function (from, count) {

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@
 This project simulates an art gallery in your browser using [REGL](https://github.com/regl-project/regl).
 It aims at reproducing the experience of a real art gallery.
 The architecture is generated using a 10km long 6th order [Hilbert Curve](https://en.wikipedia.org/wiki/Hilbert_curve).
-The paintings are asynchronously loaded from the [ARTIC](https://aggregator-data.artic.edu/home) and placed on the walls.
+The paintings are asynchronously loaded from the [ARTIC](https://api.artic.edu) and placed on the walls.
 You can use this project to display your own artworks.
 
 ## Setup


### PR DESCRIPTION
Hello from the Art Institute of Chicago!

Thanks for putting together this neat project. It's always great to see what sort of things people make with our data.

I'm a web developer on the team responsible for our public API. If you are interested, we'd love to feature your project on our website, alongside other projects that do interesting things with our API: 

https://www.artic.edu/open-access/public-api

But in order to do so, we must request that you only show public domain artworks. To make it easy, I went ahead and modified the query you're sending to only retrieve public domain artworks. I've also made a couple edits to reflect some changes that have happened in our API since this project began:

* Since early August 2020, we include `access-control-allow-origin: *` with all of our images.
* Since late July 2020, we serve our API from a new subdomain: https://api.artic.edu

Let us know if you are interested in having this project featured in our showcase! If not, no worries. I hope you find this PR useful either way. Cheers!